### PR TITLE
Add support for order by nulls first, last

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -29,14 +29,13 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     var where: Op<Boolean>? = where
         private set
 
-    override val queryToExecute: Statement<ResultSet>
-        get() {
-            val distinctExpressions = set.fields.distinct()
-            return if (distinctExpressions.size < set.fields.size) {
-                copy().adjustSlice { slice(distinctExpressions) }
-            } else
-                this
-        }
+    override val queryToExecute: Statement<ResultSet> get() {
+        val distinctExpressions = set.fields.distinct()
+        return if (distinctExpressions.size < set.fields.size) {
+            copy().adjustSlice { slice(distinctExpressions) }
+        } else
+            this
+    }
 
     override fun copy(): Query = Query(set, where).also { copy ->
         copyTo(copy)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -6,8 +6,13 @@ import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.sql.ResultSet
 import java.util.*
 
-enum class SortOrder {
-    ASC, DESC
+enum class SortOrder(val code: String, val requiresNullsFirstLastSupport: Boolean = false) {
+    ASC(code = "ASC"),
+    DESC(code = "DESC"),
+    ASC_NULLS_FIRST(code = "ASC NULLS FIRST", requiresNullsFirstLastSupport = true),
+    DESC_NULLS_FIRST(code = "DESC NULLS FIRST", requiresNullsFirstLastSupport = true),
+    ASC_NULLS_LAST(code = "ASC NULLS LAST", requiresNullsFirstLastSupport = true),
+    DESC_NULLS_LAST(code = "DESC NULLS LAST", requiresNullsFirstLastSupport = true)
 }
 
 open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuery<Query>(set.source.targetTables()) {
@@ -24,13 +29,14 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     var where: Op<Boolean>? = where
         private set
 
-    override val queryToExecute: Statement<ResultSet> get() {
-        val distinctExpressions = set.fields.distinct()
-        return if (distinctExpressions.size < set.fields.size) {
-            copy().adjustSlice { slice(distinctExpressions) }
-        } else
-            this
-    }
+    override val queryToExecute: Statement<ResultSet>
+        get() {
+            val distinctExpressions = set.fields.distinct()
+            return if (distinctExpressions.size < set.fields.size) {
+                copy().adjustSlice { slice(distinctExpressions) }
+            } else
+                this
+        }
 
     override fun copy(): Query = Query(set, where).also { copy ->
         copyTo(copy)
@@ -120,8 +126,15 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
 
                 if (orderByExpressions.isNotEmpty()) {
                     append(" ORDER BY ")
-                    orderByExpressions.appendTo {
-                        append((it.first as? ExpressionAlias<*>)?.alias ?: it.first, " ", it.second.name)
+                    orderByExpressions.appendTo { (expression, sortOrder) ->
+                        if (sortOrder.requiresNullsFirstLastSupport && !currentDialect.supportsOrderByNullsFirstLast) {
+                            error(
+                                """Sort order '${sortOrder.name}' requires extended ORDER BY support,
+                                | but the current dialect '${currentDialect.name}' does not support this"""
+                                    .trimMargin()
+                            )
+                        }
+                        append((expression as? ExpressionAlias<*>)?.alias ?: expression, " ", sortOrder.code)
                     }
                 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -555,6 +555,8 @@ interface DatabaseDialect {
 
     val supportsDualTableConcept: Boolean get() = false
 
+    val supportsOrderByNullsFirstLast: Boolean get() = false
+
     /** Returns the name of the current database. */
     fun getDatabase(): String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -135,6 +135,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
 
     override val supportsMultipleGeneratedKeys: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean get() = !TransactionManager.current().isMySQLMode
+    override val supportsOrderByNullsFirstLast: Boolean = true
 
     override fun existingIndices(vararg tables: Table): Map<Table, List<Index>> =
         super.existingIndices(*tables).mapValues { entry -> entry.value.filterNot { it.indexName.startsWith("PRIMARY_KEY_") } }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -124,6 +124,8 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
     override val supportsSubqueryUnions: Boolean = true
 
+    override val supportsOrderByNullsFirstLast: Boolean = false
+
     fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(BigDecimal("5.6"))
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -208,6 +208,7 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
     override val supportsMultipleGeneratedKeys: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
     override val supportsDualTableConcept: Boolean = true
+    override val supportsOrderByNullsFirstLast: Boolean = true
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -209,6 +209,8 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
  * PostgreSQL dialect implementation.
  */
 open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
+    override val supportsOrderByNullsFirstLast: Boolean = true
+
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun modifyColumn(column: Column<*>, nullabilityChanged: Boolean, autoIncrementChanged: Boolean, defaultChanged: Boolean): List<String> = listOf(buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -157,6 +157,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     override val needsQuotesWhenSymbolsInNames: Boolean = false
     override val supportsSequenceAsGeneratedKeys: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
+    override val supportsOrderByNullsFirstLast: Boolean = false
 
     private val nonAcceptableDefaults = arrayOf("DEFAULT")
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -144,6 +144,7 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
     override val supportsCreateSequence: Boolean = false
     override val supportsMultipleGeneratedKeys: Boolean = false
     override val supportsCreateSchema: Boolean = false
+    override val supportsOrderByNullsFirstLast: Boolean = true
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/OrderByTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/OrderByTests.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.OracleDialect
@@ -119,6 +119,37 @@ class OrderByTests : DatabaseTestsBase() {
             // St. Petersburg - 1 user
             // Prague - 0 users
             println(result)
+        }
+    }
+
+    @Test
+    fun testOrderByNullsFirst() {
+        // city IDs null, user IDs sorted ascending
+        val usersWithoutCities = listOf("alex", "smth")
+        // city IDs sorted descending, user IDs sorted ascending
+        val otherUsers = listOf("eugene", "sergey", "andrey")
+        // city IDs sorted ascending, user IDs sorted ascending
+        val otherUsersAsc = listOf("andrey", "eugene", "sergey")
+
+        val cases = listOf(
+            SortOrder.ASC_NULLS_FIRST to usersWithoutCities + otherUsersAsc,
+            SortOrder.ASC_NULLS_LAST to otherUsersAsc + usersWithoutCities,
+            SortOrder.DESC_NULLS_FIRST to usersWithoutCities + otherUsers,
+            SortOrder.DESC_NULLS_LAST to otherUsers + usersWithoutCities,
+        )
+        withCitiesAndUsers(
+            exclude = listOf(TestDB.MARIADB, TestDB.MYSQL, TestDB.SQLSERVER)
+        ) { _, users, _ ->
+            cases.forEach { (sortOrder, expected) ->
+                val r = users.selectAll().orderBy(
+                    users.cityId to sortOrder,
+                    users.id to SortOrder.ASC
+                ).toList()
+                assertEquals(5, r.size)
+                expected.forEachIndexed { index, e ->
+                    assertEquals(e, r[index][users.id])
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Currently Exposed does not support specifying if `null` should be sorted first or last in an `ORDER BY`; it only supports plain `ASC` or `DESC`.

Since we need this for Bills (see PEG-1627), I've created a PR to add this.

For an explanation on what `NULLS FIRST/LAST` does, see the relevant [PostgreSQL docs](https://postgresql.org/docs/13/interactive/queries-order.html).

Note that not all database dialects supported by Exposed support this feature, which is why I've added a dialect flag. I've researched the support of each dialect supported.

Wrt testing, I've added tests but have been unable to test with anything except H2/Sqllite, since I'm on an M1.